### PR TITLE
Guide for fixing Steam Guard code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ On linux This requires qt and curl to be installed, how it is installed depends 
 
 To run this [get a binary from Releases](https://github.com/Fallout-London/FOLON-FO4Downgrader/releases/latest) for your OS.
 
+## Issues with Steam Authenticator?
+If you tried to sign in with your Steam username and password, but are stuck at being asked for your Steam Guard code in the console window, try:
+1. Open `FOLON-Downgrader-Files\SteamFiles` in the same folder as the downgrader.exe
+2. Click the folder path at the top of your File Explorer, type `cmd` and hit Enter.
+3. In this new window, copy and paste the following (Replacing `<username>` and `<password>`, then hit Enter: `DepotDownloader.exe -username <username> -password <password> -remember-password -app 377160 -depot 377162`
+4. You should now be able to type your Steam Guard code when requested. After it starts to download, close the window, and resume using FOLON's Fallout 4 Downgrader.
+5. FOLON's Fallout 4 Downgrader should now not need a Steam Guard code, as Steam DepotDownloader should remember your token.
+
 ## To build
 Read the [build document](./build.md)
 


### PR DESCRIPTION
If you're stuck being asked for the Steam Authenticator/Steam Guard code in the console window, and can not type to send the code: Follow these steps added to the README.md file to fix the downgrade.

This workaround should fix this error a lot of users are getting:
![WindowsTerminal_uMNH8iZKJF](https://github.com/user-attachments/assets/27eb6a47-40c0-4882-8e64-8cae386c07e4)
