### PR TITLE
Prefer SteamCMD rather than Steam Console for manual steps

### DIFF
--- a/Manually.md
+++ b/Manually.md
@@ -3,55 +3,25 @@
 Pre-requisites for downgrading:
 Fallout 4, Wasteland Workshop DLC, Automatron DLC
 
-First you need to open the Steam Console [via this link](steam://open/console), copy the below and paste it into a web browser or launch Steam with the -console variable
-```
-steam://open/console
-```
-<details open>
-<summary>Image examples</summary>
+First you need to download SteamCMD [via this link]([steam://open/console](https://developer.valvesoftware.com/wiki/SteamCMD#Downloading_SteamCMD)) and extract the archive to a known place.
 
-![](./img/Manually/image1.png)
-![](./img/Manually/image2.png)
-</details>
+Then run the following command depending on your operating system. These will download the depots in the folder where you extracted SteamCMD.
 
-<br>
+**Note**: You must replace `<username>` and `<password>`, but it's suggested to keep the quotes around your password in case you have any special characters.
 
-Then input the following 1 at a time, Steam will notify you once each download is complete, at which point you can move onto the next download:
-
-<details open>
-<summary>Image examples</summary>
-
-![](./img/Manually/image3.jpeg)
-![](./img/Manually/image4.jpeg)
-</details>
-
-<br>
-
+**Windows**
 ```
-download_depot 377160 377161 7497069378349273908
-```
-```
-download_depot 377160 377162 5847529232406005096
-```
-```
-download_depot 377160 377163 5819088023757897745
-```
-```
-download_depot 377160 377164 2178106366609958945
-```
-```
-download_depot 377160 435880 1255562923187931216
-```
-```
-download_depot 377160 435870 1691678129192680960
-```
-```
-download_depot 377160 435871 5106118861901111234
+steamcmd.exe +login <username> "<password>" +download_depot 377160 377161 7497069378349273908 +download_depot 377160 377162 5847529232406005096 +download_depot 377160 377163 5819088023757897745 +download_depot 377160 377164 2178106366609958945 +download_depot 377160 435880 1255562923187931216 +download_depot 377160 435870 1691678129192680960 +download_depot 377160 435871 5106118861901111234 +quit
 ```
 
-After download each depot manually you can move the contents of each subfolder in this directory into your Fallout 4 installation folder, ensuring you overwrite all files in the destination folder
+**Unix**
+```
+./steamcmd +login <username> "<password>" +download_depot 377160 377161 7497069378349273908 +download_depot 377160 377162 5847529232406005096 +download_depot 377160 377163 5819088023757897745 +download_depot 377160 377164 2178106366609958945 +download_depot 377160 435880 1255562923187931216 +download_depot 377160 435870 1691678129192680960 +download_depot 377160 435871 5106118861901111234 +quit
+```
 
-_Note 1: The location of your ‘steamapps/content’ folder may vary if your Steam install isn’t in the default location or you’re using an Operating System other than Windows
+After download each depot manually you can move the contents of each subfolder, from within the SteamCMD folder, into your Fallout 4 installation folder, ensuring you overwrite all files in the destination folder
+
+_Note 1: The location of your ‘steamapps/content’ folder may vary if your Steam install isn’t in the default location or you’re using an Operating System other than Windows  
 Note 2: You can open up your Fallout 4 installation folder easily in Steam by right-clicking on Fallout 4 in your Steam Library and then selecting Manage > Browse Local Files:_
 
 <details open>
@@ -66,8 +36,6 @@ Note 2: You can open up your Fallout 4 installation folder easily in Steam by ri
 ```
 C:/Program Files (x86)/Steam/steamapps/content/app_377160
 ```
-
-
 
 If you want to block updates you additionally have set the following file to read only
 


### PR DESCRIPTION
Using SteamCMD will allow for downloads to chain automatically so it should _hopefully_ make it easier for users.