### PR TITLE
Remove unused imports causing issues for linux

### DIFF
--- a/FOLON-Downgrader.py
+++ b/FOLON-Downgrader.py
@@ -9,7 +9,6 @@ import stat
 from PyQt5.QtWidgets import *
 from PyQt5.QtCore import *
 from PyQt5.QtGui import QIcon, QPixmap, QFont, QFontDatabase
-from PyQt5.QtWinExtras import QWinTaskbarProgress, QWinTaskbarButton
 from QLines import *
 import argparse
 from wakepy import keep


### PR DESCRIPTION
Was trying to run the latest code ad hit this problem

![image](https://github.com/user-attachments/assets/eff00f84-6ce0-434a-a494-1e03f603b0d0)

Seem's they are unused imports - which intern break linux running as package not available on Linux.

This PR simply removes the imports from the file.